### PR TITLE
Bump pnpm version to match Vencord

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -61,7 +61,7 @@ goto checkDependencies
 exit /B 0
 
 :installpnpm
-CMD /C "npm i -g pnpm@9.1.0"
+CMD /C "npm i -g pnpm@10.4.1"
 goto restartscriptunelevated
 exit /B 0
 


### PR DESCRIPTION
Vencord bumped pnpm to 10.4.1 ( [the commit](https://github.com/Vendicated/Vencord/commit/dd714ff3c24f4464d7b3d1869e5db5b418c7c49a) ) so the build fails with 9.x, works when installing 10.4.1 before running install.bat