### PR TITLE
fix building and crashes

### DIFF
--- a/patches/src/userplugins/betterMicrophone.desktop/components/MicrophoneSettingsModal.tsx
+++ b/patches/src/userplugins/betterMicrophone.desktop/components/MicrophoneSettingsModal.tsx
@@ -17,7 +17,7 @@
 */
 
 import { Flex } from "@components/Flex";
-import { Switch } from "@components/Switch";
+import { Switch } from "@webpack/common";
 import { ModalSize } from "@utils/modal";
 import { Card, Forms, Select, Slider, TextInput, useEffect, useState } from "@webpack/common";
 import { SelectOption } from "@webpack/types";

--- a/patches/src/userplugins/betterScreenshare.desktop/components/ScreenshareSettingsModal.tsx
+++ b/patches/src/userplugins/betterScreenshare.desktop/components/ScreenshareSettingsModal.tsx
@@ -17,7 +17,7 @@
 */
 
 import { Flex } from "@components/Flex";
-import { Switch } from "@components/Switch";
+import { Switch } from "@webpack/common";
 import { ModalSize, openModalLazy } from "@utils/modal";
 import { Button, Card, Forms, React, Select, Slider, TextInput, useEffect, useState } from "@webpack/common";
 import { SelectOption } from "@webpack/types";

--- a/patches/src/userplugins/clientSideBlock/index.tsx
+++ b/patches/src/userplugins/clientSideBlock/index.tsx
@@ -99,6 +99,7 @@ function shouldHideUser(userId: string, channelId?: string) {
 
 // This is really horror
 function isRoleAllBlockedMembers(roleId, guildId) {
+	if (!GuildRoleStore) return false;
     const role = GuildRoleStore.getRole(guildId, roleId);
     if (!role) return false;
 

--- a/patches/src/userplugins/customSounds/components/SoundOverrideComponent.tsx
+++ b/patches/src/userplugins/customSounds/components/SoundOverrideComponent.tsx
@@ -5,7 +5,7 @@
  */
 
 import { classNameFactory } from "@api/Styles";
-import { makeRange } from "@components/PluginSettings/components";
+import { makeRange } from "@utils/types";
 import { Margins } from "@utils/margins";
 import { classes } from "@utils/misc";
 import { useForceUpdater } from "@utils/react";

--- a/patches/src/userplugins/favGifSearch/README.md
+++ b/patches/src/userplugins/favGifSearch/README.md
@@ -1,0 +1,5 @@
+# FavoriteGifSearch
+
+Adds a search bar to favorite gifs.
+
+![Screenshot](https://github.com/Vendicated/Vencord/assets/45497981/19552adc-d921-4153-976e-e9361dc8fdaf)

--- a/patches/src/userplugins/favGifSearch/index.tsx
+++ b/patches/src/userplugins/favGifSearch/index.tsx
@@ -1,0 +1,263 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2023 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { definePluginSettings } from "@api/Settings";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { findByPropsLazy } from "@webpack";
+import { useCallback, useEffect, useRef, useState } from "@webpack/common";
+import { favoritedGifs, FavoritedGifsChangedCallback, Gif } from "userplugins/favoritedGifsProvider";
+
+interface SearchBarComponentProps {
+	ref?: React.MutableRefObject<any>;
+	autoFocus: boolean;
+	className: string;
+	size: string;
+	onChange: (query: string) => void;
+	onClear: () => void;
+	query: string;
+	placeholder: string;
+}
+
+type TSearchBarComponent =
+	React.FC<SearchBarComponentProps> & { Sizes: Record<"SMALL" | "MEDIUM" | "LARGE", string>; };
+
+interface Instance {
+	dead?: boolean;
+	state: {
+		resultType?: string;
+	};
+	props: {
+		favorites: Gif[],
+	},
+	forceUpdate: () => void;
+}
+
+
+const containerClasses: { searchBar: string; } = findByPropsLazy("searchBar", "searchBarFullRow");
+
+export const settings = definePluginSettings({
+	searchOption: {
+		type: OptionType.SELECT,
+		description: "The part of the url you want to search",
+		options: [
+			{
+				label: "Entire Url",
+				value: "url"
+			},
+			{
+				label: "Path Only (/somegif.gif)",
+				value: "path"
+			},
+			{
+				label: "Host & Path (tenor.com somgif.gif)",
+				value: "hostandpath",
+				default: true
+			}
+		] as const
+	}
+});
+
+export default definePlugin({
+	name: "FavoriteGifSearchProviderPatch",
+	authors: [Devs.Aria],
+	description: "Adds a search bar to favorite gifs.",
+	dependencies: ["FavoritedGifsProvider"],
+
+	patches: [
+		{
+			find: "renderHeaderContent()",
+			replacement: [
+				{
+					// https://regex101.com/r/07gpzP/1
+					// ($1 renderHeaderContent=function { ... switch (x) ... case FAVORITES:return) ($2) ($3 case default:return r.jsx(($<searchComp>), {...props}))
+					match: /(renderHeaderContent\(\).{1,150}FAVORITES:return)(.{1,150});(case.{1,200}default:return\(0,\i\.jsx\)\((?<searchComp>\i\..{1,10}),)/,
+					replace: "$1 this.state.resultType === 'Favorites' ? $self.renderSearchBar(this, $<searchComp>) : $2;$3"
+				},
+				// {
+				// 	// to persist filtered favorites when component re-renders.
+				// 	// when resizing the window the component rerenders and we loose the filtered favorites and have to type in the search bar to get them again
+				// 	match: /(,suggestions:\i,favorites:)(\i),/,
+				// 	replace: "$1$self.getFav($2),favCopy:$2,"
+				// }
+
+			]
+		}
+	],
+
+	settings,
+
+	getTargetString,
+
+	instance: null as Instance | null,
+	callback: null as FavoritedGifsChangedCallback | null,
+
+	renderSearchBar(instance: Instance, SearchBarComponent: TSearchBarComponent) {
+		if (!this.instance) {
+			this.instance = instance;
+
+			if (this.callback) {
+				const index = favoritedGifs.callbacks.findIndex(callback => callback === this.callback);
+
+				if (index) {
+					favoritedGifs.callbacks.splice(index);
+				}
+			}
+
+			this.callback = favorites => {
+				if (!this.instance || this.instance.dead) return favorites;
+				const { favorites: filteredFavorites } = this.instance.props;
+
+				return filteredFavorites != null && filteredFavorites?.length !== favorites.length ? filteredFavorites : favorites;
+			};
+
+			favoritedGifs.callbacks.push(this.callback);
+		}
+		else {
+			this.instance = instance;
+		}
+		return (
+			<ErrorBoundary noop>
+				<SearchBar instance={instance} SearchBarComponent={SearchBarComponent} />
+			</ErrorBoundary>
+		);
+	},
+
+	// getFav(favorites: Gif[]) {
+	// 	if (!this.instance || this.instance.dead) return favorites;
+	// 	const { favorites: filteredFavorites } = this.instance.props;
+
+	// 	return filteredFavorites != null && filteredFavorites?.length !== favorites.length ? filteredFavorites : favorites;
+
+	// }
+});
+
+
+function SearchBar({ instance, SearchBarComponent }: { instance: Instance; SearchBarComponent: TSearchBarComponent; }) {
+	const [query, setQuery] = useState("");
+	const ref = useRef<{ containerRef?: React.MutableRefObject<HTMLDivElement>; } | null>(null);
+
+	const onChange = useCallback((searchQuery: string) => {
+		setQuery(searchQuery);
+		const { props } = instance;
+
+		// return early
+		if (searchQuery === "") {
+			props.favorites = favoritedGifs.favorites;
+			instance.forceUpdate();
+			return;
+		}
+
+
+		// scroll back to top
+		ref.current?.containerRef?.current
+			.closest("#gif-picker-tab-panel")
+			?.querySelector("[class|=\"content\"]")
+			?.firstElementChild?.scrollTo(0, 0);
+
+
+		const result =
+			favoritedGifs.favorites
+				.map(gif => ({
+					score: fuzzySearch(searchQuery.toLowerCase(), getTargetString(gif.url ?? gif.src).replace(/(%20|[_-])/g, " ").toLowerCase()),
+					gif,
+				}))
+				.filter(m => m.score != null) as { score: number; gif: Gif; }[];
+
+		result.sort((a, b) => b.score - a.score);
+		props.favorites = result.map(e => e.gif);
+
+		instance.forceUpdate();
+	}, [instance.state]);
+
+	useEffect(() => {
+		return () => {
+			instance.dead = true;
+		};
+	}, []);
+
+	return (
+		<SearchBarComponent
+			ref={ref}
+			autoFocus={true}
+			className={containerClasses.searchBar}
+			size={SearchBarComponent.Sizes.MEDIUM}
+			onChange={onChange}
+			onClear={() => {
+				setQuery("");
+				if (instance.props.favorites != null) {
+					instance.props.favorites = favoritedGifs.favorites;
+					instance.forceUpdate();
+				}
+			}}
+			query={query}
+			placeholder="Search Favorite Gifs"
+		/>
+	);
+}
+
+
+
+export function getTargetString(urlStr: string) {
+	let url: URL;
+	try {
+		url = new URL(urlStr);
+	} catch (err) {
+		// Can't resolve URL, return as-is
+		return urlStr;
+	}
+
+	switch (settings.store.searchOption) {
+		case "url":
+			return url.href;
+		case "path":
+			if (url.host === "media.discordapp.net" || url.host === "tenor.com")
+				// /attachments/899763415290097664/1095711736461537381/attachment-1.gif -> attachment-1.gif
+				// /view/some-gif-hi-24248063 -> some-gif-hi-24248063
+				return url.pathname.split("/").at(-1) ?? url.pathname;
+			return url.pathname;
+		case "hostandpath":
+			if (url.host === "media.discordapp.net" || url.host === "tenor.com")
+				return `${url.host} ${url.pathname.split("/").at(-1) ?? url.pathname}`;
+			return `${url.host} ${url.pathname}`;
+
+		default:
+			return "";
+	}
+}
+
+function fuzzySearch(searchQuery: string, searchString: string) {
+	let searchIndex = 0;
+	let score = 0;
+
+	for (let i = 0; i < searchString.length; i++) {
+		if (searchString[i] === searchQuery[searchIndex]) {
+			score++;
+			searchIndex++;
+		} else {
+			score--;
+		}
+
+		if (searchIndex === searchQuery.length) {
+			return score;
+		}
+	}
+
+	return null;
+}

--- a/patches/src/userplugins/favoritedGifsProvider/index.tsx
+++ b/patches/src/userplugins/favoritedGifsProvider/index.tsx
@@ -1,0 +1,56 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export interface Gif {
+	format: number;
+	id: string;
+	src: string;
+	url: string;
+	height: number;
+	width: number;
+}
+
+export type FavoritedGifsChangedCallback = (favorites: Gif[]) => void;
+
+class FavoritedGifs {
+	callbacks: FavoritedGifsChangedCallback[] = {} as FavoritedGifsChangedCallback[];
+	favorites: Gif[] = {} as Gif[];
+}
+
+export const favoritedGifs = new FavoritedGifs();
+
+export default definePlugin({
+	name: "FavoritedGifsProvider",
+	description: "Patch to export the favorited GIFs.",
+	authors: [Devs.Aria, {
+		name: "hexa",
+		id: 573643611317600256n,
+	}],
+
+	patches: [
+		{
+			find: "renderHeaderContent()",
+			replacement: [
+				{
+					match: /(,suggestions:\i,favorites:)(\i),/,
+					replace: "$1$self.getFav($2),"
+				}
+			]
+		},
+	],
+
+	getFav(favorites: Gif[]) {
+		favoritedGifs.favorites = favorites;
+		for (let index = 0; index < favoritedGifs.callbacks.length; index++) {
+			favoritedGifs.callbacks[index](favorites);
+		}
+
+		return favoritedGifs.favorites;
+	},
+});

--- a/patches/src/userplugins/mediaPlaybackSpeed/index.tsx
+++ b/patches/src/userplugins/mediaPlaybackSpeed/index.tsx
@@ -9,7 +9,7 @@ import "./styles.css";
 import { definePluginSettings } from "@api/Settings";
 import { classNameFactory } from "@api/Styles";
 import ErrorBoundary from "@components/ErrorBoundary";
-import { makeRange } from "@components/PluginSettings/components";
+import { makeRange } from "@utils/types";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { ContextMenuApi, FluxDispatcher, Heading, Menu, React, Tooltip, useEffect } from "@webpack/common";

--- a/patches/src/userplugins/philsPluginLibrary/components/AuthorSummaryItem.tsx
+++ b/patches/src/userplugins/philsPluginLibrary/components/AuthorSummaryItem.tsx
@@ -21,7 +21,7 @@ import { useEffect, UserUtils, useState } from "@webpack/common";
 import { User } from "discord-types/general";
 import React from "react";
 
-import { createDummyUser, types, UserSummaryItem } from "../../philsPluginLibrary";
+import { createDummyUser, types, UserSummaryItem } from "..";
 
 export interface AuthorUserSummaryItemProps extends Partial<React.ComponentProps<types.UserSummaryItem>> {
     authors: PluginAuthor[];

--- a/patches/src/userplugins/philsPluginLibrary/components/settingsModal/SettingsModalCard.tsx
+++ b/patches/src/userplugins/philsPluginLibrary/components/settingsModal/SettingsModalCard.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Switch } from "@components/Switch";
+import { Switch } from "@webpack/common";
 import { Card, Forms } from "@webpack/common";
 import React from "react";
 

--- a/patches/src/userplugins/philsPluginLibrary/components/settingsModal/SettingsModalProfilesCard.tsx
+++ b/patches/src/userplugins/philsPluginLibrary/components/settingsModal/SettingsModalProfilesCard.tsx
@@ -19,7 +19,7 @@
 import { Flex } from "@components/Flex";
 import { Select, TextInput, useEffect, useState } from "@webpack/common";
 
-import { PluginSettings, ProfilableStore } from "../../../philsPluginLibrary";
+import { PluginSettings, ProfilableStore } from "../..";
 import { CopyButton, DeleteButton, NewButton, SaveButton } from "../buttons";
 import { SettingsModalCard } from "./SettingsModalCard";
 import { SettingsModalCardItem } from "./SettingsModalCardItem";

--- a/patches/src/userplugins/philsPluginLibrary/components/settingsPanel/SettingsPanelButton.tsx
+++ b/patches/src/userplugins/philsPluginLibrary/components/settingsPanel/SettingsPanelButton.tsx
@@ -20,7 +20,7 @@ import { classes } from "@utils/misc";
 import { Button } from "@webpack/common";
 import React, { JSX } from "react";
 
-import { panelClasses } from "../../../philsPluginLibrary";
+import { panelClasses } from "../..";
 
 export type IconComponent = <T extends { className: string; }>(props: T) => JSX.Element;
 export interface SettingsPanelButtonProps extends Partial<React.ComponentProps<typeof Button>> {

--- a/patches/src/userplugins/philsPluginLibrary/discordModules/components.tsx
+++ b/patches/src/userplugins/philsPluginLibrary/discordModules/components.tsx
@@ -19,6 +19,6 @@
 import { LazyComponent } from "@utils/react";
 import { findByCode } from "@webpack";
 
-import { types } from "../";
+import { types } from "..";
 
 export const UserSummaryItem = LazyComponent<React.ComponentProps<types.UserSummaryItem>>(() => findByCode("defaultRenderUser", "showDefaultAvatarsForNullUsers"));

--- a/patches/src/userplugins/philsPluginLibrary/patches/audio.ts
+++ b/patches/src/userplugins/philsPluginLibrary/patches/audio.ts
@@ -20,7 +20,7 @@ import { Logger } from "@utils/Logger";
 import { lodash } from "@webpack/common";
 
 import { MicrophoneProfile, MicrophoneStore } from "../../betterMicrophone.desktop/stores";
-import { ProfilableStore, replaceObjectValuesIfExist, types } from "../../philsPluginLibrary";
+import { ProfilableStore, replaceObjectValuesIfExist, types } from "..";
 
 export function getDefaultAudioTransportationOptions(connection: types.Connection) {
     return {

--- a/patches/src/userplugins/philsPluginLibrary/types/discordModules/modules/connection.ts
+++ b/patches/src/userplugins/philsPluginLibrary/types/discordModules/modules/connection.ts
@@ -18,8 +18,8 @@
 
 import TypedEmitter from "typed-emitter";
 
-import { Framerate, Resolution } from "../../../types";
-import { Conn, FramerateReducer, VideoQualityManager } from "./";
+import { Framerate, Resolution } from "../..";
+import { Conn, FramerateReducer, VideoQualityManager } from ".";
 
 export const ConnectionEvent = {
     SPEAKING: "speaking",

--- a/patches/src/userplugins/philsPluginLibrary/types/discordModules/modules/framerateReducer.ts
+++ b/patches/src/userplugins/philsPluginLibrary/types/discordModules/modules/framerateReducer.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Connection, VideoQualityManager } from "./";
+import { Connection, VideoQualityManager } from ".";
 
 export type FramerateReducer = FramerateReducer_ & {
     connection: Connection;

--- a/patches/src/userplugins/philsPluginLibrary/types/discordModules/modules/mediaEngine.ts
+++ b/patches/src/userplugins/philsPluginLibrary/types/discordModules/modules/mediaEngine.ts
@@ -18,7 +18,7 @@
 
 import TypedEmitter from "typed-emitter";
 
-import { Connection } from "./";
+import { Connection } from ".";
 
 export const MediaEngineEvent = {
     REMOVE_LISTENER: "removeListener",

--- a/patches/src/userplugins/philsPluginLibrary/types/discordModules/modules/videoQualityManager.ts
+++ b/patches/src/userplugins/philsPluginLibrary/types/discordModules/modules/videoQualityManager.ts
@@ -16,8 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Bitrate, Framerate, Resolution } from "../../";
-import { Connection } from "./";
+import { Bitrate, Framerate, Resolution } from "../..";
+import { Connection } from ".";
 
 export type VideoQualityManager = VideoQualityManager_ & {
     connection: Connection;

--- a/patches/src/userplugins/voiceChatUtils/index.tsx
+++ b/patches/src/userplugins/voiceChatUtils/index.tsx
@@ -6,7 +6,7 @@
 
 import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { definePluginSettings } from "@api/Settings";
-import { makeRange } from "@components/PluginSettings/components";
+import { makeRange } from "@utils/types";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { findStoreLazy } from "@webpack";


### PR DESCRIPTION
this fixes build errors caused by a few components being moved to @webpack/common
there was also a patch made to isRoleAllBlockedMembers to check if GuildRoleStore is undefined since that was causing crashes, i haven't tested that plugin but i'd rather wait for that to get patched by the creator so this is good enough to prevent crashing (even with the plugin disabled there was crashes)

this also includes a new favoritedGifsProvider API which makes the patch needed for vc-gif-collections and favGifSearch a shared API so both plugins can work at the same time, however since favGifSearch is a built-in plugin it'll be duplicated and since i wasn't sure of the code being good enough for vencord i never made a PR there, though i should make a draft for that eventually to make sure that is done properly, i've been running that patch for around a month so far and it has worked perfectly for me